### PR TITLE
Removal of quick links

### DIFF
--- a/components/menu/menuOptions.js
+++ b/components/menu/menuOptions.js
@@ -1,8 +1,8 @@
 import { ImCalculator, ImHome } from 'react-icons/im';
-import {BsFillPeopleFill, BsFillCalendarMonthFill, BsLink45Deg, BsCalendarWeek} from 'react-icons/bs'
-import {MdNightlightRound, MdPublishedWithChanges} from 'react-icons/md'
-import {IoCreate} from 'react-icons/io5'
-import {GrSchedules} from 'react-icons/gr'
+import { BsFillPeopleFill, BsFillCalendarMonthFill, BsLink45Deg, BsCalendarWeek } from 'react-icons/bs'
+import { MdNightlightRound, MdPublishedWithChanges } from 'react-icons/md'
+import { IoCreate } from 'react-icons/io5'
+import { GrSchedules } from 'react-icons/gr'
 
 
 
@@ -42,17 +42,17 @@ export const optionsMenu = [
         path: '/bankCycle',
         label: 'Ciclo de banco de horas'
     },
-    {
-        icon: <BsLink45Deg />,
-        path: '/quickLinks',
-        label: 'Links Rápidos'
-    },
+    // {
+    //     // icon: <BsLink45Deg />,
+    //     // path: '/quickLinks',
+    //     // label: 'Links Rápidos'
+    // },
     {
         icon: <BsFillPeopleFill />,
         path: '/about',
         label: 'Colaboradores'
     },
-    
+
 
 ];
 


### PR DESCRIPTION
I removed the label "quick links".
This label is not used

![Screenshot_21](https://github.com/pablobion/ahgutils/assets/111452237/86b3344a-c0f1-4687-8443-72b0961bd8e8)
